### PR TITLE
Print debug handles vectors

### DIFF
--- a/R/print_debug.R
+++ b/R/print_debug.R
@@ -18,7 +18,7 @@ print_debug <- function(...) {
   for (symbol in symbols) {
     name <- as.character(symbol)
     val <- parent.env[[name]]
-    # special logic for handling NULL
+    # special logic for handling non-scalar values
     if (is.null(val)) {
       if (name %in% names(parent.env)) {
         # cast to string or the sprintf will fail
@@ -26,6 +26,12 @@ print_debug <- function(...) {
       } else {
         # provide helpful debug without breaking the program
         val <- sprintf("ERROR - no %s defined", name)
+      }
+    } else if (length(val) > 1) {
+      if (is.character(val)) {
+        val <- sprintf("c('%s')", paste(val, collapse = "', '"))
+      } else {
+        val <- sprintf("c(%s)", toString(val))
       }
     }
     message(sprintf("%s: %s", name, val))

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By default all functions are exported. That means you have two options
 
 # Functions to use
 
-* `ihme.covid::get_script_dir()`
+## `ihme.covid::get_script_dir()`
 
 Returns the directory your R script is in or NULL (if it fails).
 
@@ -27,7 +27,7 @@ this_dir <- ihme.covid::get_script_dir()
 source(file.path(this_dir, "my_functions.R"))
 ```
 
-* `print_debug`
+## `print_debug`
 
 Convenience function for printing values in the namespace.
 
@@ -48,7 +48,7 @@ age_bins: 5
 outfile: /path/to/output.csv
 ```
 
-* `get_output_dir`
+## `get_output_dir`
 
 Wraps common logic associated with getting the next output directory.
 
@@ -66,7 +66,7 @@ get_output_dir(
   date = "2020_05_01")
 ```
 
-* `get_latest_output_date_index`
+## `get_latest_output_date_index`
 
 From `hospitalization_sim_functions.r`
 

--- a/tests/testthat/test_print_debug.R
+++ b/tests/testthat/test_print_debug.R
@@ -18,3 +18,12 @@ test_that("Typos, NA, and NULL values are handled", {
   expect_message(print_debug(nu), "nu: NULL")
   expect_message(print_debug(baz), "baz: ERROR - no baz defined")
 })
+
+test_that("vector values are sensible", {
+  # use fixed = TRUE to do non-regex based comparisons
+  num.vals <- c(1, 4, 19)
+  expect_message(print_debug(num.vals), "num.vals: c(1, 4, 19)", fixed = TRUE)
+
+  char.vals <- c("foo", "bar", "baz")
+  expect_message(print_debug(char.vals), "char.vals: c('foo', 'bar', 'baz')", fixed = TRUE)
+})


### PR DESCRIPTION
* pretty print vectors. Currently you get this
```
> run_vers <- c("2020_05_13.15", "2020_05_06.07", "2020_05_07.31")
> print_debug(run_vers)
run_vers: 2020_05_03.15run_vers: 2020_05_06.07run_vers: 2020_05_07.31
```
This modifies it to produce what we want:
```
run_vers: c('2020_05_03.15', '2020_05_06.07', '2020_05_07.31')
```
* Update README.md to use section headers (`##`) instead of unordered lists (`*`). This just makes the page easier to scan