### PR TITLE
Error on missing locations

### DIFF
--- a/R/error_on_missing_locations.R
+++ b/R/error_on_missing_locations.R
@@ -1,0 +1,12 @@
+error_on_missing_locations <- function(data, ..., hierarchy, hierarchy.value = "location_id") {
+  if (missing("hierarchy")) {
+    stop("hierarchy not provided - must be provided as a named argument")
+  }
+  miss <- setdiff(hierarchy[[hierarchy.value]], data)
+  if (length(miss)) {
+    # as.character unsuitable - you need deparse
+    # https://stackoverflow.com/a/24632946
+    data.name <- deparse(substitute(data))
+    stop(sprintf("%s missing values for %s(s): %s", data.name, hierarchy.value, paste(sort(miss), collapse = ",")))
+  }
+}

--- a/README.md
+++ b/README.md
@@ -92,3 +92,19 @@ sorted <- ihme.covid::sort_hierarchy(dt)
 # Same requirements as above. This time, list "Spokane County" and "Italy" before anything else
 sorted <- ihme.covid::sort_hierarchy(dt, prepend = c(3539, 86))
 ```
+
+## `error_on_missing_locations`
+
+Errors if your data is missing 1 or more values relative to the location hierarchy.
+
+Add a line like this to your code:
+```
+ihme.covid::error_on_missing_locations(shape@data$loc_id, hierarchy = hierarchy)
+```
+
+and get an error message if your data is missing locations in the hierarchy!
+
+```
+Error in ihme.covid::error_on_missing_locations(shape@data$loc_id, hierarchy = hierarchy) :
+  shape@data$loc_id missing values for location_id(s): 24,367,369,413,416
+```

--- a/tests/testthat/test_error_on_missing_locations.R
+++ b/tests/testthat/test_error_on_missing_locations.R
@@ -1,0 +1,46 @@
+test_that("errors are generated on missing values for location_ids", {
+  hierarchy <- data.table::data.table(location_id = 1:5)
+  my_data <- c(1, 2, 6) # lacks values for 3, 4, 5 (all in hierarchy)
+
+  # must error
+  expect_error(error_on_missing_locations(my_data, hierarchy = hierarchy))
+
+  # error must include the missing values
+  expect_error(error_on_missing_locations(my_data, hierarchy = hierarchy),
+    "missing values for location_id(s): 3,4,5",
+    fixed = TRUE # test fixed string value, not regex
+  )
+})
+
+
+test_that("error_on_missing_locations can use non-location_id fields", {
+  hierarchy <- data.table::data.table(location_name = c("Russia", "USA"))
+  my_data <- c("USA", "USA")
+
+  expect_error(
+    error_on_missing_locations(my_data, hierarchy = hierarchy, hierarchy.value = "location_name"),
+    "missing values for location_name(s): Russia",
+    fixed = TRUE
+  )
+})
+
+test_that("error_on_missing_locations required hierarchy as a named argument", {
+  hierarchy <- data.table::data.table(location_id = 1:5)
+  my_data <- c(1, 2, 6)
+
+  expect_error(error_on_missing_locations(my_data, hierarchy),
+    "hierarchy not provided - must be provided as a named argument"
+  )
+})
+
+
+test_that("error_on_missing_locations provides name of value", {
+  hierarchy <- data.table::data.table(location_id = 1:5)
+  my_data <- list(ids = c(1, 2, 6))
+
+  expect_error(
+    error_on_missing_locations(my_data$ids, hierarchy = hierarchy),
+    "my_data$ids missing values for location_id(s): 3,4,5",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test_print_debug.R
+++ b/tests/testthat/test_print_debug.R
@@ -27,3 +27,8 @@ test_that("vector values are sensible", {
   char.vals <- c("foo", "bar", "baz")
   expect_message(print_debug(char.vals), "char.vals: c('foo', 'bar', 'baz')", fixed = TRUE)
 })
+
+test_that("nested calls work", {
+  container <- list(ids = c(1, 2, 4))
+  expect_message(print_debug(container$ids), "container$ids: c(1, 2, 4)", fixed = TRUE)
+})


### PR DESCRIPTION
Add a generalized function for comparing data sets to the location hierarchy and providing helpful errors if they aren't in harmony.

This function is to be used in the "fail fast" logic for the updated temperature code