### PR TITLE
BUGFIX - handle silly singularity quirk with umask

### DIFF
--- a/R/get_output_dir.R
+++ b/R/get_output_dir.R
@@ -7,7 +7,11 @@ get_output_dir <- function(root, date) {
   dir.name <- sprintf("%s.%02i", date, cur.version + 1)
   dir.path <- file.path(root, dir.name)
   if (!dir.exists(dir.path)) {
+    # handle quirk with singularity image default umask
+    old.umask <- Sys.umask()
+    Sys.umask("002")
     dir.create(dir.path, showWarnings = FALSE, recursive = TRUE, mode = "0777")
+    Sys.umask(old.umask)
   }
   return(dir.path)
 }


### PR DESCRIPTION
This fixes an annoying quirk of the singularity images + default umask which leads to 755 permissions (owner writable only) when we want 775 permissions (permissive writes)