### PR TITLE
BUGFIX - exclude files/folders that break logic

### DIFF
--- a/R/get_latest_output_date_index.R
+++ b/R/get_latest_output_date_index.R
@@ -12,7 +12,8 @@ get_latest_output_date_index <- function(dir, date) {
   currentfolders <- list.files(dir)
 
   # subset to date
-  date_dirs <- grep(date, currentfolders, value = T)
+  pat <- sprintf("^%s[.]\\d{2}$", date)
+  date_dirs <- grep(pat, currentfolders, value = T)
 
   if (length(date_dirs) == 0) {
     return(0)


### PR DESCRIPTION
Updated to use stronger regex patterns so similarly named things do not lead to an NA result