### PR TITLE
Feature/elineb/order pdf pages

### DIFF
--- a/R/pdf_array_job.R
+++ b/R/pdf_array_job.R
@@ -61,7 +61,7 @@ pdf_array_job <- function(jobs_file, r_script, final_out_dir,
   
   # Once jobs have finished, bind them back together
   bind_job_name = paste0("bind_", job_name)
-  bind_script = '/home/j/temp/elineb/rlibs/ihme.covid/bind_pdf.R'
+  bind_script = system.file("bind_pdf.R", package="ihme.covid", lib.loc="/ihme/covid-19/.r-packages/current", mustWork=TRUE)
   command <- paste0(
     "qsub", 
     " -l fthread=", fthread, ",fmem=", fmem, ",h_rt=", h_rt, ",archive=TRUE",

--- a/inst/bind_pdf.R
+++ b/inst/bind_pdf.R
@@ -4,13 +4,13 @@ bind_pdfs = function(temp_out_dir, final_out_dir, write_file_name){
   files = list.files(temp_out_dir, full.names=T, include.dirs=F)
   
   # Add zeros to job ID so they will sort in the order of jobs file
-  order = data.table::data.table(file = files)
-  order[, job_id:=gsub(paste0(temp_out_dir, "/"), "", files)]
-  order[, job_id:=gsub(".png", "", job_id)]
-  order = order[order(as.numeric(job_id))]
+  file_order = data.table::data.table(file = files)
+  file_order[, job_id:=gsub(paste0(temp_out_dir, "/"), "", files)]
+  file_order[, job_id:=gsub(".png", "", job_id)]
+  file_order = file_order[order(as.numeric(job_id))]
   
   pdf(paste0(final_out_dir, "/", write_file_name))
-  for (file in order$file){
+  for (file in file_order$file){
     grob = grid::rasterGrob(png::readPNG(file, native = FALSE), interpolate = FALSE)
     gridExtra::grid.arrange(grob)
   }

--- a/inst/bind_pdf.R
+++ b/inst/bind_pdf.R
@@ -7,7 +7,9 @@ bind_pdfs = function(temp_out_dir, final_out_dir, write_file_name){
   order = data.table::data.table(file = files)
   order[, order:=gsub(paste0(temp_out_dir, "/"), "", files)]
   order[, order:=gsub(".png", "", order)]
-  order[nchar(order)==1, order:=paste0("0", order)]
+  order[nchar(order)==1, order:=paste0("000", order)]
+  order[nchar(order)==2, order:=paste0("00", order)]
+  order[nchar(order)==3, order:=paste0("0", order)]
   order = order[order(order)]
   
   pdf(paste0(final_out_dir, "/", write_file_name))

--- a/inst/bind_pdf.R
+++ b/inst/bind_pdf.R
@@ -3,8 +3,15 @@
 bind_pdfs = function(temp_out_dir, final_out_dir, write_file_name){
   files = list.files(temp_out_dir, full.names=T, include.dirs=F)
   
+  # Add zeros to job ID so they will sort in the order of jobs file 
+  files = gsub(paste0(temp_out_dir, "/"), "", files)
+  files = gsub(".png", "", files)
+  files[nchar(files)==1] = paste0("0", files[nchar(files)==1])
+  files = sort(files)
+  
   pdf(paste0(final_out_dir, "/", write_file_name))
   for (file in files){
+    file = paste0(temp_out_dir, "/", file, ".png")
     grob = grid::rasterGrob(png::readPNG(file, native = FALSE), interpolate = FALSE)
     gridExtra::grid.arrange(grob)
   } 

--- a/inst/bind_pdf.R
+++ b/inst/bind_pdf.R
@@ -5,12 +5,9 @@ bind_pdfs = function(temp_out_dir, final_out_dir, write_file_name){
   
   # Add zeros to job ID so they will sort in the order of jobs file
   order = data.table::data.table(file = files)
-  order[, order:=gsub(paste0(temp_out_dir, "/"), "", files)]
-  order[, order:=gsub(".png", "", order)]
-  order[nchar(order)==1, order:=paste0("000", order)]
-  order[nchar(order)==2, order:=paste0("00", order)]
-  order[nchar(order)==3, order:=paste0("0", order)]
-  order = order[order(order)]
+  order[, job_id:=gsub(paste0(temp_out_dir, "/"), "", files)]
+  order[, job_id:=gsub(".png", "", job_id)]
+  order = order[order(as.numeric(job_id))]
   
   pdf(paste0(final_out_dir, "/", write_file_name))
   for (file in order$file){

--- a/inst/bind_pdf.R
+++ b/inst/bind_pdf.R
@@ -1,22 +1,22 @@
-#' Binds together the PDFs from an array job - is called by 'pdf_array_job()'. 
+#' Binds together the PDFs from an array job - is called by 'pdf_array_job()'.
 #'
 bind_pdfs = function(temp_out_dir, final_out_dir, write_file_name){
   files = list.files(temp_out_dir, full.names=T, include.dirs=F)
   
-  # Add zeros to job ID so they will sort in the order of jobs file 
-  files = gsub(paste0(temp_out_dir, "/"), "", files)
-  files = gsub(".png", "", files)
-  files[nchar(files)==1] = paste0("0", files[nchar(files)==1])
-  files = sort(files)
+  # Add zeros to job ID so they will sort in the order of jobs file
+  order = data.table::data.table(file = files)
+  order[, order:=gsub(paste0(temp_out_dir, "/"), "", files)]
+  order[, order:=gsub(".png", "", order)]
+  order[nchar(order)==1, order:=paste0("0", order)]
+  order = order[order(order)]
   
   pdf(paste0(final_out_dir, "/", write_file_name))
-  for (file in files){
-    file = paste0(temp_out_dir, "/", file, ".png")
+  for (file in order$file){
     grob = grid::rasterGrob(png::readPNG(file, native = FALSE), interpolate = FALSE)
     gridExtra::grid.arrange(grob)
-  } 
+  }
   dev.off()
-} 
+}
 
 parser <- argparse::ArgumentParser()
 parser$add_argument("--temp-out-dir", required=TRUE, help="Temporary directory where files are saved")


### PR DESCRIPTION
Modifying previous PR to stop using code on j/temp, and to ensure that PDFs are sorted in the same order as the jobs file. 