### PR TITLE
fix failing CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,12 +38,12 @@ jobs:
           r-version: ${{ matrix.r-version }}
       - name: Install ubuntu dependecies for rgdal
         run: |
-          sudo apt install libgdal-dev
+          sudo apt install libgdal-dev libcurl4-gnutls-dev libharfbuzz-dev  libfribidi-dev
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "devtools"))
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
-      - name: Test 
+      - name: Test
         run: devtools::test('.', reporter = c('summary','fail'))
         shell: Rscript {0}


### PR DESCRIPTION
There is an issue with CI test failing due to textshaping library causing devtools package to not install.
This is related to missing system libraries.